### PR TITLE
fix reading list comma bug

### DIFF
--- a/scripts/currently-reading.js
+++ b/scripts/currently-reading.js
@@ -14,9 +14,9 @@ function formatTitles(titleList) {
     if (i === 0) {
       titleHTML = linked;
     } else if (i !== 0 && i !== titleList.length - 1) {
-      titleHTML += `, ${linked}`;
+      titleHTML += `, ${linked},`;
     } else {
-      titleHTML += `, & ${linked}`;
+      titleHTML += ` & ${linked}`;
     }
   }
   return titleHTML;


### PR DESCRIPTION
I mistakenly put the comma in the wrong part of the string when I snuck in an oxford comma for the reading list in a previous PR. This corrects the error.
