### PR TITLE
fix reading list

### DIFF
--- a/scripts/currently-reading.js
+++ b/scripts/currently-reading.js
@@ -18,9 +18,9 @@ function formatTitles(titleList) {
     if (i === 0) {
       titleHTML = linked;
     } else if (i !== 0 && i !== titleList.length - 1) {
-      titleHTML += `, ${linked},`;
+      titleHTML += `, ${linked}`;
     } else {
-      titleHTML += ` & ${linked}`;
+      titleHTML += `${titleList.length > 2 ? "," : ""} & ${linked}`;
     }
   }
   return titleHTML;


### PR DESCRIPTION
Fixes #110

Now when we have more than 4 books in the list, our comma usage should be correct.
