### PR TITLE
tweak tagbox css

### DIFF
--- a/_includes/assets/css/tags.css
+++ b/_includes/assets/css/tags.css
@@ -1,7 +1,7 @@
 div.tagbox {
-    outline: 0.1em dashed;
+    border: 2px dashed #000;
+    padding: 15px;
     box-shadow: -0.5em 0.5em rgba(238, 238, 51, 0.6);
-    padding: 1em;
 }
 
 ul.taglist {
@@ -22,5 +22,5 @@ li.selectedtag {
     background: #ee3;
     padding-right: 0.1em;
     padding-left: 0.1em;
-    outline: 0.07em solid;
+    outline: 2px solid;
 }


### PR DESCRIPTION
The new `tagbox` that allows you to see a quick overview of all the tags & then jump to one was nearly there. But on mobile, it had some unwanted artifacts.

I don't want to tinker with this forever, so I'm just gonna copy/pasta from my blockquote formatting with some small changes & call it a day.
