### PR TITLE
hide tag filter options

### DIFF
--- a/_includes/tagfilter.njk
+++ b/_includes/tagfilter.njk
@@ -1,4 +1,5 @@
-<b>filter by tag</b>
+{%- if section != "notes" -%}<details  open>{%- else -%}<details>{%- endif -%}
+    <summary><b>filter by tag</b></summary>
 <div class="tagbox">
 	<ul class="taglist">
 {% set uniqueTags = collections.posts | taglist %}
@@ -11,3 +12,4 @@
 {% endfor %}
 	</ul>
 </div>
+</details>


### PR DESCRIPTION
This is a small quality of life update. I added the quick links for tag filters, but it felt a bit in your face to be included on the main landing page. 

This PR introduces some small sleight of hand (thanks to `<details open>`) to hide the option by default, but have them displayed if you're on a tag filter page.
