### PR TITLE
use css to style svg

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -60,7 +60,7 @@ module.exports = function (eleventyConfig) {
       .translate([344, 168.56]);
     const path = d3.geoPath(projection);
 
-    const mapSvg = `<svg width="688" height="337.12" viewBox="0 0 688 337.12" style="width: 60%; height: auto; display: block; margin-left: auto; margin-right: auto; border: 2px solid #000;">
+    const mapSvg = `<svg width="688" height="337.12" viewBox="0 0 688 337.12">
       <g>
         <path d="${path(graticule)}" stroke="#000" fill="none"></path>
         <path d="${path(worldData)}" stroke="#fff" fill="#ccc"></path>

--- a/_includes/assets/css/post.css
+++ b/_includes/assets/css/post.css
@@ -41,3 +41,27 @@ audio {
         width: 60vw;
     }
 }
+
+/* For devices smaller larger a phablet */
+@media (min-width: 550px) {
+    svg {
+        width: 75%;
+        height: auto;
+        display: block;
+        margin-left: auto;
+        margin-right: auto;
+        border: 2px solid #000;
+    }
+}
+
+/* For devices smaller than a phablet */
+@media (max-width: 550px) {
+    svg {
+        width: 100%;
+        height: auto;
+        display: block;
+        margin-left: auto;
+        margin-right: auto;
+        border: 2px solid #000;
+    }
+}

--- a/_includes/assets/css/post.css
+++ b/_includes/assets/css/post.css
@@ -35,6 +35,14 @@ audio {
     width: 35%;
 }
 
+svg {
+    height: auto;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    border: 2px solid #000;
+}
+
 /* For devices larger than 700px */
 @media (min-width: 700px) {
     .footnote-item {
@@ -46,11 +54,6 @@ audio {
 @media (min-width: 550px) {
     svg {
         width: 75%;
-        height: auto;
-        display: block;
-        margin-left: auto;
-        margin-right: auto;
-        border: 2px solid #000;
     }
 }
 
@@ -58,10 +61,5 @@ audio {
 @media (max-width: 550px) {
     svg {
         width: 100%;
-        height: auto;
-        display: block;
-        margin-left: auto;
-        margin-right: auto;
-        border: 2px solid #000;
     }
 }


### PR DESCRIPTION
Bit silly, but I did some inline CSS stuff with my map SVGs. Looked good working on my laptopt, but turns out that hardcoded width ratios make the mobile experience kind of crap. 

This addresses that and keeps things in some slightly tidier css files.
