### PR TITLE
use location instead of lat/lon

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -2,6 +2,7 @@ const { DateTime } = require("luxon");
 const CleanCSS = require("clean-css");
 const d3 = require("d3-geo", "d3-geo-projection");
 const worldData = require("./_data/ne_110m_admin_0_countries.json");
+const { cities } = require("./_data/metadata.json");
 const markdownIt = require("markdown-it");
 const markdownItFootnote = require("markdown-it-footnote");
 
@@ -47,12 +48,11 @@ module.exports = function (eleventyConfig) {
   });
 
   // Generate travel post map SVG
-  eleventyConfig.addShortcode("cartographer", (lat, lon) => {
-    if (!lat || !lon) return "";
+  eleventyConfig.addShortcode("cartographer", (location) => {
+    if (!cities[location]) return "";
+    const { lat, lon } = cities[location];
 
     const graticule = d3.geoGraticule10();
-    const poi = d3.geoCircle().center([lon, lat]).radius(2);
-    const bullseye = d3.geoCircle().center([lon, lat]).radius(1);
     const projection = d3
       .geoEqualEarth()
       .scale(400)
@@ -70,7 +70,7 @@ module.exports = function (eleventyConfig) {
     </svg>`;
 
     return `
-    <div align=center><b>latitude</b>: ${lat}, <b>longitude</b>: ${lon}</div>
+    <div align=center><b>a dispatch from:</b> ${location.toUpperCase()}</div>
      ${mapSvg}
     <br />
      `;

--- a/_data/metadata.json
+++ b/_data/metadata.json
@@ -1,12 +1,17 @@
 {
   "title": "cyber(b)space",
   "url": "https://cyberb.space",
-  "location": {
+  "outpost": {
     "city": "Mumbai (मुंबई)",
     "country": "India"
   },
   "author": {
     "name": "Josh Erb",
     "email": "josh@cyberb.space"
+  },
+  "cities": {
+    "mumbai": { "lat": 19.07, "lon": 72.88 },
+    "dc": { "lat": 38.89, "lon": -77.03 },
+    "chicago": { "lat": 41.85, "lon": -87.65 }
   }
 }

--- a/_includes/post.njk
+++ b/_includes/post.njk
@@ -10,7 +10,7 @@ section: post
     <span class="highlight">{{ content | striptags | wordcount }} words.</span>
   </small>
 </p>
-{% cartographer lat, lon %}
+{% cartographer location %}
 
 {{ content | safe }}
 

--- a/pages/home.md
+++ b/pages/home.md
@@ -18,7 +18,7 @@ Like most personal sites, I use this space to house two different aspects of my 
 
 If you prefer the social web rather than just being talked at, you can find me squatting <a rel="me" href="https://union.place/@riastrad">over on Mastodon</a>.
 
-> Currently located: {{ metadata.location.city }}, {{ metadata.location.country }}
+> Currently located: {{ metadata.outpost.city }}, {{ metadata.outpost.country }}
 > Currently reading: <span id="currently-reading"><a href="https://oku.club/user/riastrad/collection/reading">...loading</a></span>
 
 </div>

--- a/posts/2024/rasmalai.md
+++ b/posts/2024/rasmalai.md
@@ -10,8 +10,7 @@ tags:
   - review
   - food
   - brief
-lat: 19.07
-lon: 72.88
+location: mumbai
 permalink: /notes/{{ page.date | dateYear }}/{{ title | slugify }}/index.html
 ---
 

--- a/posts/2024/the-improvised-city.md
+++ b/posts/2024/the-improvised-city.md
@@ -7,8 +7,7 @@ tags:
   - post
   - travel
   - india
-lat: 19.07
-lon: 72.88
+location: mumbai
 permalink: /notes/{{ page.date | dateYear }}/{{ title | slugify }}/index.html
 ---
 


### PR DESCRIPTION
I didn't like having to copy/paste values for `lat` & `lon` whenever I wanted to add a location to a post, so I've changed my shortcode to expect a friendly name "location" that I've defined and then lookup the correct values to use in my metadata.

I think ultimately, I'll probably want to have a separate JSON file to manage these cities & any data I want to include about them. But for now, keeping them in `metadata.json` is fine.
