### PR TITLE
fix post links

### DIFF
--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -2,11 +2,10 @@
 <p>
 		<a class="post-title" href="{{ post.url | url }}">
 		{% if post.data.title %}
-			{{ post.data.title }}
+			{{ post.data.title }}</a>
 		{% else %}
-			Untitled
+			Untitled</a>
 		{% endif %}
-		</a>
 
     <time datetime="{{ post.date | machineDate }}">
 			<i>posted {{ post.date | readableDate }}</i>


### PR DESCRIPTION
This is a very small detail, but I noticed that my underline link effect was extending beyond the word for titles on the blog landing page. This might not be the most elegant fix, but it resolves the visual issue.
