### PR TITLE
fix bandcamp post

### DIFF
--- a/posts/2023/why-does-the-earth-give-us-platforms-to-love.md
+++ b/posts/2023/why-does-the-earth-give-us-platforms-to-love.md
@@ -17,7 +17,7 @@ Now, the company that bought Bandcamp has publicly stated that they "have no pla
 
 As I'm writing this, I'm listening to an album I only discovered because of [Bandcamp's editorial work](https://daily.bandcamp.com/album-of-the-day/kara-jackson-why-does-the-earth-give-us-people-to-love-review). Kara Jackson's _Why Does The Earth Give Us People To Love?_ It's beautiful and moody and would not be in my life if it weren't for the people so carelessly discarded by Songtradr.
 
-<div style="margin: auto;width: 50%"><iframe style="border: 0; width: 400px; height: 472px;" src="https://bandcamp.com/EmbeddedPlayer/album=1829566835/size=large/bgcol=ffffff/linkcol=333333/artwork=small/transparent=true/" seamless><a href="https://karajackson.bandcamp.com/album/why-does-the-earth-give-us-people-to-love">Why Does The Earth Give Us People To Love? by Kara Jackson</a></iframe></div>
+<div align=center><iframe style="border: 0; height: 472px;" src="https://bandcamp.com/EmbeddedPlayer/album=1829566835/size=large/bgcol=ffffff/linkcol=333333/artwork=small/transparent=true/" seamless><a href="https://karajackson.bandcamp.com/album/why-does-the-earth-give-us-people-to-love">Why Does The Earth Give Us People To Love? by Kara Jackson</a></iframe></div>
 
 Only one thought consoles at moments like this: Art and music will live on long after the destruction of market capitalism is a distant memory. Its glistening fangs no longer feasting on the fruit given freely by our yearning souls.
 


### PR DESCRIPTION
On mobile, the iframe would annoyingly be shifted over to the right. This is because of the hardcoded width that bandcamp recommends in their embed widget. Dropped that and changed to a simple `align=center` for the enclosing div & now it looks much better.

| **before** | **after** |
| --- | --- |
| <img width="284" alt="image" src="https://github.com/user-attachments/assets/47bd00fe-af11-4955-b484-51e513fc35a3"> | <img width="285" alt="image" src="https://github.com/user-attachments/assets/c58fb81b-e8d1-426b-9a13-8017bce2c655"> |

We lose the album artwork because the iframe is never wide enough, but I think I actually prefer this when I look at them side by side. Keeps the aesthetic of the site consistent.

I don't plan to embed things very often. But if I do, then I'll probably move some of this into a dedicated CSS file so that I can easily keep things consistent.