### PR TITLE
update discuss footer link

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -97,6 +97,10 @@ module.exports = function (eleventyConfig) {
     return hoverableHTML;
   });
 
+  eleventyConfig.addFilter("encodeURI", (link) => {
+    return encodeURI(link);
+  });
+
   // Date formatting stuff
   eleventyConfig.addFilter("readableDate", (dateObj) => {
     return DateTime.fromJSDate(dateObj).toFormat("MMM dd, yyyy");

--- a/_includes/footer.njk
+++ b/_includes/footer.njk
@@ -1,7 +1,7 @@
 <footer>
      <a href="https://cyberb.space/feed.xml">subscribe</a> |
      <a href="https://github.com/riastrad/cyberbspace/tree/main/{{ page.inputPath }}">view source</a> |
-     <a href="{{ metadata.author.social }}">discuss</a>
+     <a href="mailto:{{ metadata.author.email }}?subject=[cyberbspace] thoughts on {{ page.url | encodeURI }}">discuss</a>
       <p>
         &copy; Josh Erb {{ page.date | dateYear }}
       </p>


### PR DESCRIPTION
Instead of the broken social link, let's opt for direct emails instead.

(I may live to regret this, I'm sure.)