### PR TITLE
fix blog-pic sizing

### DIFF
--- a/_includes/assets/css/post.css
+++ b/_includes/assets/css/post.css
@@ -23,6 +23,8 @@ div.dithered-hover:focus img.blog-pic:first-child {
     margin-left: auto;
     margin-right: auto;
     margin-bottom: 1em;
+    max-height: 500px;
+    width: auto;
 }
 
 .center-text {


### PR DESCRIPTION
The latest edition of my  ongoing battle with displaying pictures on the blog.

Don't want the verticle pictures to take up the entire screen if you're scrolling on a laptop.
