### PR TITLE
[chore] commit to monospace

### DIFF
--- a/_includes/assets/css/base.css
+++ b/_includes/assets/css/base.css
@@ -62,11 +62,7 @@ body {
     font-size: 1.5em; /* currently ems cause chrome bug misinterpreting rems on body element */
     line-height: 1.6;
     font-weight: 400;
-    font-family:
-        Courier New,
-        monospace,
-        Helvetica,
-        Arial,
+    font-family: Menlo, "Courier New", Courier, monospace, Helvetica, Arial,
         sans-serif;
     background-color: #ffffff;
     color: #222;
@@ -146,7 +142,7 @@ h6 {
     margin-top: 0;
     margin-bottom: 2rem;
     font-weight: 300;
-    font-family: Palatino, Helvetica, sans-serif;
+    text-transform: uppercase;
 }
 h1 {
     font-size: 5rem;
@@ -213,7 +209,7 @@ a {
 a.post-title {
     background-color: #fff;
     font-size: 2.4rem;
-    font-family: Palatino, Helvetica, sans-serif;
+    text-transform: uppercase;
 }
 
 @media (max-width: 550px) {

--- a/_includes/blog.njk
+++ b/_includes/blog.njk
@@ -4,6 +4,7 @@ section: notes
 permalink: /notes/index.html
 ---
 {% include "tagfilter.njk" %}
+<hr />
 {{ content | safe }}
 {% set postslist = collections.posts %}
 {% include "postslist.njk" %}

--- a/pages/home.md
+++ b/pages/home.md
@@ -14,16 +14,16 @@ I'm a writer & software engineer.
 
 This site is the primary conduit through which my lived experience flows into the digital world. Here is the high level view, in case you don't have time to stick around:
 
-<ins>Where I am:</ins>
+**WHERE I AM**
 {{ metadata.outpost.city }}, {{ metadata.outpost.country }}
 
-<ins>What I'm reading:</ins>
+**WHAT I'M READING**
 {{ reading | books }}
 
-<ins>Recent published writing:</ins>
+**RECENT PUBLISHED WRITING**
 <a href="{{ publications.first.url }}">{{ publications.first.title }}</a> in *{{ publications.first.publisher }}*
 
-<ins>My latest note:</ins>
+**MY LATEST NOTE**
 <a href="{{ collections.posts.last.url }}">{{ collections.posts.last.data.title }}</a> ({{ collections.posts.last.data.date | readableDate }})
 
 If you prefer the social web, you can find me squatting <a rel="me" href="{{ metadata.author.social.mastodon }}">over on Mastodon</a> or experimenting with self-promotion <a href="{{ metadata.author.social.bluesky }}">over on Bluesky</a>.

--- a/tags.njk
+++ b/tags.njk
@@ -20,7 +20,7 @@ layout: base.njk
 {% include "tagfilter.njk" %}
 {% set postslist = collections[ tag ] %}
 
-<br /><br />
+<hr />
 
 There are <strong>{{ postslist | length }}</strong> posts with the tag <span class="highlight">#{{ tag }}</span> <a title="clear tag filter" href="/notes/" style="background:#fff;">🆇</a>
 


### PR DESCRIPTION
Toying with the idea of just going all in on one monospace font, instead of the current setup where I have a serif for headers and mono for the body.

I'm endlessly inspired by [The Monospace Web](https://owickstrom.github.io/the-monospace-web/) and I noticed that it's all just one font and uses `uppercase` to make headers distinct. 

This branch is me messing with that to see how it feels. Also, I like Menlo, it's been growing on me ever since I updated my notes app to use it. I can have that be the main font and just expect any non apple users to get Courier or the fallback monospace.

Here are some pictures of what these changes look like at present:
![Screen Shot 2024-12-10 at 12 24 08 PM](https://github.com/user-attachments/assets/ae57d725-2416-45b5-bacf-9a5b2b2bd614)
![Screen Shot 2024-12-10 at 12 23 59 PM](https://github.com/user-attachments/assets/0d0fb7c6-b070-4f6f-8a7e-fef977a5b1e6)
![Screen Shot 2024-12-10 at 12 23 54 PM](https://github.com/user-attachments/assets/6b3aa6d4-b0c7-4e0a-89cc-cb74d8d84def)

