### PR TITLE
fixed travel post map dimensions

### DIFF
--- a/_includes/assets/css/post.css
+++ b/_includes/assets/css/post.css
@@ -67,7 +67,6 @@ img#overviewMap {
 }
 
 img.svgMap {
-    height: auto;
     display: block;
     margin-left: auto;
     margin-right: auto;
@@ -84,14 +83,16 @@ img.svgMap {
 /* For devices larger than a phablet */
 @media (min-width: 550px) {
     img.svgMap {
-        width: 75%;
+        width: 725px;
+        height: 360px;
     }
 }
 
 /* For devices smaller than a phablet */
 @media (max-width: 550px) {
     img.svgMap {
-        width: 100%;
+        width: 365px;
+        height: 200px;
     }
 
     blockquote {

--- a/tags.njk
+++ b/tags.njk
@@ -23,7 +23,7 @@ layout: base.njk
 <hr />
 
 {% if tag === "travel" %}
-    {% cartographer "all" %}
+    {% cartographer "all" %}<br />
 {% endif %}
 
 There are <strong>{{ postslist | length }}</strong> posts with the tag <a title="clear tag filter" href="/notes/" style="cursor: context-menu">#{{ tag }}</a>


### PR DESCRIPTION
I was finding it annoying to have travel posts load, see text for half a second, then have it pushed down as the browser calculated the appropriate map dimensions. This should make the experience a bit better by definining pixel heights for the images up front. Because they sit inside the body container, it should still be dynamic enough on different devices. If I see it broken anywhere, I'll try to think of something more clever.
