### PR TITLE
[bugfix] only reading one book

### DIFF
--- a/bin/shelf.js
+++ b/bin/shelf.js
@@ -21,7 +21,11 @@ module.exports.fetchBooksFromRSS = async (rss) => {
   }
 
   const rawXML = await body.text();
-  const books = parser.parse(rawXML).rss.channel.item;
+  let books = parser.parse(rawXML).rss.channel.item;
+
+  // when there's only one book the rss item is an object, not an array
+  if (typeof books === undefined) books = [books];
+
   const cleanBooks = books.map((bk) => {
     const book = {
       title: bk.title,


### PR DESCRIPTION
Small little hiccup with the `fetchBooksFromRss` function that only surfaces when I pull an RSS feed that only has one book in it. In this case, the parsed XML returns an object and not an array of objects as expected. 

There's probably a more clever way to address this variation, but I don't want to lose too much sleep over it so I'm just going with a check on whether or not the returned list of items has a `length` property or not.
