### PR TITLE
[enhancement] bookshelf upgrades

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -170,9 +170,17 @@ module.exports = function (eleventyConfig) {
     return encodeURI(link);
   });
 
+  eleventyConfig.addFilter("uppercase", (text) => {
+    return typeof text === "string" ? text.toUpperCase() : text;
+  });
+
   // Date formatting stuff
   eleventyConfig.addFilter("readableBookDate", (dateString) => {
-    return DateTime.fromRFC2822(dateString).toFormat("yyyy-MM-dd");
+    return DateTime.fromRFC2822(dateString).toFormat("MMM dd, yyyy");
+  });
+
+  eleventyConfig.addFilter("bookDateYear", (dateString) => {
+    return DateTime.fromRFC2822(dateString).toFormat("yyyy");
   });
 
   eleventyConfig.addFilter("readableDate", (dateObj) => {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -92,6 +92,8 @@ module.exports = function (eleventyConfig) {
   // currently this only returns an HTML widget that
   // shows the aqi for Mumbai, though this could easily be changed
   eleventyConfig.addAsyncShortcode("aqi", async (location) => {
+    const fallback = `<table align=center><tr><td>⚠️ failed to retrieve AQI reading for ${location.toUpperCase()} ⚠️</td></tr></table>`;
+    return fallback;
     console.log(`[cyberb] pulling AQI data for ${location}`);
     const { statusCode, body } = await request(
       "https://airnowgovapi.com/reportingarea/get",
@@ -104,7 +106,6 @@ module.exports = function (eleventyConfig) {
       },
     );
 
-    const fallback = `<table align=center><tr><td>⚠️ failed to retrieve AQI reading for ${location.toUpperCase()} ⚠️</td></tr></table>`;
     if (statusCode !== 200) {
       console.log(`[cyberb] AQI data call failed with error ${statusCode}`);
       return fallback;

--- a/_includes/assets/css/books.css
+++ b/_includes/assets/css/books.css
@@ -1,0 +1,36 @@
+div.shelf {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+div.shelvedbook {
+    color: #fff;
+    background: #000;
+    border: 2px solid #000;
+    height: 16rem;
+    width: 9rem;
+    text-wrap: balance;
+    text-overflow: ellipsis;
+    line-height: 1.4em;
+    font-size: 1.25rem;
+    padding: 0.5em;
+    margin: 0.25em;
+    transition-property: transform;
+    transition-duration: 0.75s;
+}
+
+div.shelvedbook:hover,
+div.shelvedbook:focus {
+    box-shadow: 0 0 0.5em 0.5em rgba(238, 238, 51);
+    transform: translateX(-5%) translateY(-5%);
+}
+
+div.shelvedbook a {
+    background: none;
+    color: #fff;
+}
+
+div.shelvedbook:hover a,
+div.shelvedbook:focus a {
+    background: none;
+}

--- a/_includes/bookreview.njk
+++ b/_includes/bookreview.njk
@@ -1,0 +1,4 @@
+<h2>booklog: {{book.title}}</h2>
+
+I finished reading <a href="{{ book.link }}">{{ book.title }}</a> by {{ book.author }} on {{ book.finished | readableBookDate }}.
+<hr />

--- a/_includes/head.njk
+++ b/_includes/head.njk
@@ -21,6 +21,9 @@
   {% set css %}
     {% include "assets/css/normalize.css" %}
     {% include "assets/css/base.css" %}
+    {% if title === "shelf." %}
+        {% include "assets/css/books.css" %}
+    {% endif %}
     {% if date %}
       {% include "assets/css/prism.css" %}
       {% include "assets/css/post.css" %}

--- a/bin/technical-dictionary.txt
+++ b/bin/technical-dictionary.txt
@@ -1,3 +1,7 @@
+currentYear
+bookDateYear
+endcapture
+endunless
 shelf-life-1.png
 shelf-life-2.png
 eleventy

--- a/books.njk
+++ b/books.njk
@@ -1,0 +1,14 @@
+---
+title: filtered notes.
+pagination:
+  data: books.have_read
+  size: 1
+  alias: book
+  title: {{ book.title }}
+permalink: /shelf/{{ book.author | slugify }}/{{ book.title | slugify }}/
+layout: base.njk
+---
+
+{% include "bookreview.njk" %}
+
+<a class="button" href="{{ '/shelf/' | url }}"><< shelf.</a>

--- a/pages/bookshelf.md
+++ b/pages/bookshelf.md
@@ -11,10 +11,9 @@ navtitle: bookshelf
 
 ## Currently Reading
 
-| **started** | **title** | **author** |
-| :--      | :--       | :--        |
-{% for book in books.reading %}| {{ book.started | readableBookDate }} | [{{ book.title }}]({{ book.link }}) | {{ book.author }} |
-{% endfor %}
+<div class="shelf">
+    {% for book in books.reading %}<div class="shelvedbook"><a href="{{ book.link }}">{{ book.title | uppercase }}</a><p>{{ book.author }}</p></div>{%endfor%}
+</div>
 
 ---
 
@@ -22,9 +21,16 @@ navtitle: bookshelf
 
 I have read **{{ books.have_read.length }}**  books since I started keeping track of them digitally.
 
-| **finished** | **title** | **author** |
-| :--      | :--       | :--        |
-{% for book in books.have_read %}| {{ book.finished | readableBookDate }} | [{{ book.title }}]({{ book.link }}) | {{ book.author }} |
+{% for book in books.have_read %}
+  {% capture currentYear %}{{ book.finished | bookDateYear }}{% endcapture %}
+  {% if year != currentYear %}
+  {% unless year == undefined %}</div><br />{% endunless %}
+  {% assign year = currentYear %}
+  ### {{ currentYear }}
+  <div class="shelf">
+  {% endif %}
+  <div class="shelvedbook"><a href="/shelf/{{ book.author | slugify }}/{{ book.title | slugify }}">{{ book.title | uppercase }}<p>{{ book.author }}</p></a></div>
+  {% if forloop.last == true %}</div>{% endif %}
 {% endfor %}
-
+</div>
 <hr />


### PR DESCRIPTION
The table format of the initial bookshelf implementation was grating on me.

This PR does a few things to improve the experience:
1. Stop using a table, and make some book-like `<div>` elements instead.
1. Add some advanced liquid templating to split `have_read` books into different shelves based on the year they were read.
1. Instead of having each book link to an external page, they now link to a dedicated "booklog" page. These pages are pretty sparse at the moment, but they start to prepare the way for storing more data (isbn, publisher, start date) and reviews in my workflow.
