### PR TITLE
[bugfix] fix book pages' title property

### DIFF
--- a/_includes/head.njk
+++ b/_includes/head.njk
@@ -1,6 +1,9 @@
 <head>
   <meta charset="utf-8"/>
-  <title>{{ title or metadata.title }}</title>
+  {% if book.title %}
+    {% set reviewtitle = ["Thoughts on ", book.title] | join %}
+  {% endif %}
+  <title>{{ title or reviewtitle or metadata.title }}</title>
 
   <!-- Mobile Specific Meta -->
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -10,7 +13,7 @@
 
   <!-- All about that social content -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta property="og:title" content="{{ title }}" />
+  <meta property="og:title" content="{{ title or reviewtitle }}" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://cyberb.space{{ page.url }}" />
   {% if summary %}<meta property="og:description" content="{{ summary }}" />{% endif %}

--- a/books.njk
+++ b/books.njk
@@ -1,5 +1,4 @@
 ---
-title: filtered notes.
 pagination:
   data: books.have_read
   size: 1


### PR DESCRIPTION
Noticed today that my book pages (still under construction) had erroneously used a copy/pasted value for the `<title>` element in each pages `<head>`. This resolves that issue and gives every book page the new title <kbd>Thoughts on {{ book.title }}</kbd> which feels better.

More to come with these pages.
