### PR TITLE
[fix] update book data if any fields differ

### DIFF
--- a/bin/shelf.js
+++ b/bin/shelf.js
@@ -59,7 +59,6 @@ const cleanupDataFields = (notionResponse) => {
     return cleanBook;
   });
 
-  console.log("[debug] clean books:", cleanBooks.length);
   return cleanBooks;
 };
 
@@ -85,8 +84,8 @@ module.exports.bookListsAreSame = (previousList, newlyFetchedList) => {
   return (
     previousList.length === newlyFetchedList.length &&
     previousList.every((book) =>
-      newlyFetchedList.some(
-        (bk) => book.title === bk.title && book.author === bk.author,
+      newlyFetchedList.some((bk) =>
+        Object.keys(book).forEach((key) => book[key] === bk[key]),
       ),
     )
   );


### PR DESCRIPTION
Making a small tweak here so that the list will update if there are any differences in the book data from the previous pull. Whereas previously I only updated the list if the title or author fields were different.
