### PR TITLE
[feature] add book review rss feed

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -158,6 +158,10 @@ module.exports = function (eleventyConfig) {
     return DateTime.fromJSDate(dateObj).toUTC().toISO();
   });
 
+  eleventyConfig.addFilter("reviewFeedDate", (dateString) => {
+    return DateTime.fromFormat(dateString, "yyyy-MM-dd").toISO();
+  });
+
   eleventyConfig.addFilter("dateYear", (dateObj) => {
     return DateTime.fromJSDate(dateObj).toFormat("yyyy");
   });

--- a/_includes/head.njk
+++ b/_includes/head.njk
@@ -19,6 +19,7 @@
   {% if summary %}<meta property="og:description" content="{{ summary }}" />{% endif %}
   <meta property="og:image" content="https://cyberb.space/img/{% if summary %}post{% else %}site{% endif %}-preview-card.jpg" />
   <link rel="alternate" type="application/rss+xml" href="/feed.xml" title="notes rss">
+  <link rel="alternate" type="application/rss+xml" href="/shelf/feed.xml" title="book reviews rss">
 
   <!-- Style -->
   {% set css %}

--- a/_includes/rss.njk
+++ b/_includes/rss.njk
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
 <generator uri="https://www.11ty.dev/" version="2.0.1">11ty</generator>
-<link href="{{ metadata.url }}/feed.xml" rel="self" type="application/atom+xml"/>
+<link href="https://cyberb.space{{ page.url }}" rel="self" type="application/atom+xml"/>
 <link href="{{ metadata.url }}" rel="alternate" type="text/html"/>
 <updated>{{ page.date | feedDate }}</updated>
-<id>{{ metadata.url }}/feed.xml</id>
-<title type="html">{{ metadata.title }}</title>
-<subtitle>or, the personal blog of a recovering software engineer</subtitle>
+<id>https://cyberb.space{{ page.url }}</id>
 <author>
   <name>{{ metadata.author.name }}</name>
   <uri>{{ metadata.url }}</uri>

--- a/book-review-feed.njk
+++ b/book-review-feed.njk
@@ -1,0 +1,25 @@
+---
+layout: rss.njk
+section: bookshelf
+permalink: shelf/feed.xml
+---
+<title type="html">cyber(b)space book reviews</title>
+<subtitle>bespoke thoughts on various books</subtitle>
+{% for book in books.have_read %}
+{% if book.review %}
+{% set link = [metadata.url, "/shelf/", book.author | slugify , "/", book.title | slugify] | join %}
+<entry>
+  <title type="html">Booklog: {{ book.title }}</title>
+  <link href="{{ link }}" rel="alternate" type="text/html" title="Booklog: {{ book.title }}" />
+  <published>{{ book.finished | reviewFeedDate }}</published>
+  <updated>{{ book.finished | reviewFeedDate }}</updated>
+  <id>{{ link }}</id>
+  <author>
+   <name>{{ metadata.author.name }}</name>
+   <uri>{{ metadata.url }}</uri>
+  </author>
+  <summary type="html">Thoughts on <em>{{ book.title }}</em> by {{ book.author }}</summary>
+  <content type="html" xml:base="{{ link }}">{{ book.review }}</content>
+</entry>
+{% endif %}
+{% endfor %}

--- a/feed.njk
+++ b/feed.njk
@@ -3,6 +3,8 @@ layout: rss.njk
 section: notes
 permalink: /feed.xml
 ---
+<title type="html">cyber(b)space notes</title>
+<subtitle>or, the personal blog of one Joshua James Erb</subtitle>
 {% set postslist = collections.posts %}
 {% for post in postslist | reverse %}
 <entry>


### PR DESCRIPTION
Resolve #209

Having an RSS feed for each tag is overkill. But since I now have my book reviews in a dedicated place that is not included in the updates to the RSS feed. I am adding a separate feed for those who might be interested.
