### PR TITLE
[bugfix] unhandled reference error

### DIFF
--- a/_data/books/have_read.json
+++ b/_data/books/have_read.json
@@ -1,5 +1,15 @@
 [
     {
+        "title": "Deaf Republic",
+        "author": "Ilya Kaminsky",
+        "isbn": 9781555978310,
+        "started": "2025-07-05",
+        "finished": "2025-07-06",
+        "publisher": "Graywolf Press",
+        "pages": 76,
+        "link": "https://openlibrary.org/works/OL20152493W/Deaf_Republic"
+    },
+    {
         "title": "Aliss at the Fire",
         "author": "Jon Fosse",
         "isbn": 9781804271025,

--- a/bin/shelf.js
+++ b/bin/shelf.js
@@ -48,7 +48,7 @@ const cleanupDataFields = (notionResponse) => {
     if (pages && pages.number !== null) {
       cleanBook.pages = pages.number;
     }
-    if (situ && situ.rich_text) {
+    if (situ && situ.rich_text && situ.rich_text.length > 0) {
       cleanBook.situ = situ.rich_text[0].plain_text;
     }
     if (review && review.rich_text.length > 0) {


### PR DESCRIPTION
Looks like #248 introduced a regression in pulling book data if books have no assigned `situ` path.

This corrects the issue and brings the data up to date.
