### PR TITLE
[feat:shelf] add total pages per year as a tooltip 

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -49,6 +49,17 @@ module.exports = function (eleventyConfig) {
       const booksThisYear = books.filter((book) =>
         book.finished.includes(year),
       );
+
+      return booksThisYear.reduce((tot, curr) => (tot += curr), 0);
+    },
+  );
+
+  eleventyConfig.addShortcode(
+    "readingPagesYear",
+    function (books, year = DateTime.now().year) {
+      const booksThisYear = books.filter((book) =>
+        book.finished.includes(year),
+      );
       const pages = booksThisYear.reduce((tot, currentBook) => {
         if (currentBook.pages === undefined) return tot;
         return (tot += currentBook.pages);

--- a/pages/bookshelf.md
+++ b/pages/bookshelf.md
@@ -30,7 +30,7 @@ navtitle: bookshelf
   {% if year != currentYear %}
   {% unless year == undefined %}</div><br />{% endunless %}
   {% assign year = currentYear %}
-  ### {{ currentYear }}  <small>({% readingProgressYear books.have_read currentYear %})</small>
+  ### {{ currentYear }}  <small>(<span title="{% readingPagesYear books.have_read currentYear %} pages">{% readingProgressYear books.have_read currentYear %}</span>)</small>
   <div class="shelf">
   {% endif %}
   <div class="shelvedbook"><a href="/shelf/{{ book.author | slugify }}/{{ book.title | slugify }}">{{ book.title | uppercase }}<p>{{ book.author }}</p></a></div>


### PR DESCRIPTION
Had the idea this afternoon to add a little tooltip to the total number of books I read each year so you can see how many pages that translates to:

<img width="367" height="156" alt="image" src="https://github.com/user-attachments/assets/2864c223-7676-40fa-b547-a91b6606287c" />


Pretty easy to add, so I'm going to go ahead and roll with it. Worth noting that I didn't have page data when I pulled stuff outta goodreads and my other tracker, so these page counts are pretty inaccurate for any year that isn't 2025 and after. Fixing that would require a substantial data backfill that I don't feel inclined to wrestle with at the moment.
