### PR TITLE
[fix] modify prepopulated email subject

### DIFF
--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -8,9 +8,7 @@
 		{% include "navbar.njk" %}
 		<div class="container">
 			{{ content | safe }}
-
 			{% include "footer.njk" %}
-
 		</div>
 	</body>
 </html>

--- a/_includes/footer.njk
+++ b/_includes/footer.njk
@@ -1,7 +1,12 @@
 <footer>
      <a href="https://cyberb.space/feed.xml">subscribe</a> |
      <a href="https://github.com/riastrad/cyberbspace/tree/main/{{ page.inputPath }}">view source</a> |
-     <a href="mailto:{{ metadata.author.email }}?subject=[cyberbspace] thoughts on {{ page.url | encodeURI }}">discuss</a>
+    {% set isBook = r/\/shelf\//g %}
+    {% if isBook.test(page.url) %}
+     <a href="mailto:{{ metadata.author.email }}?subject=[cyberbspace comment] thoughts on review of '{{ book.title | encodeURI }}'">discuss</a>
+    {% else %}
+     <a href="mailto:{{ metadata.author.email }}?subject=[cyberbspace comment] thoughts on post '{{ title | encodeURI }}'">discuss</a>
+    {% endif %}
       <p>
         &copy; Josh Erb {{ page.date | dateYear }}
       </p>


### PR DESCRIPTION
It's been bugging me for a while that the email subject for anyone that clicked on the `mailto:` link of a page was just prepoluated with the page's url. This change modifies the footer logic to be more human readable (and it handles the edge case for shelf pages).
