### PR TITLE
 [fix] add readable date when hovering relative date

### DIFF
--- a/_includes/bookprogress.njk
+++ b/_includes/bookprogress.njk
@@ -1,6 +1,6 @@
 <h2>NOW READING: {{book.title}}</h2>
 
-<p>I started reading <a href="{{ book.link }}">{{ book.title }}</a> by {{ book.author }} {{ book.started | relativeBookDate }}.</p>
+<p>I started reading <a href="{{ book.link }}">{{ book.title }}</a> by {{ book.author }} <span title="{{ book.started | readableBookDate }}">{{ book.started | relativeBookDate }}</span>.</p>
 
 <h4>Progress</h4>
 <!-- insert progress bar here -->


### PR DESCRIPTION
I like the relative dates for the books I'm currently reading, but I still want to see the cold hard facts of _when_ I started reading. 

This small change updates the template to show the readable date when the relative one is hovered, like so:

<img width="717" height="241" alt="image" src="https://github.com/user-attachments/assets/46f43abb-5aae-4210-8818-501bbedc87cf" />
