### PR TITLE
fix: upgrade liquidjs to 10.26.0 (CVE-2026-45618)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "clean-css": "^4.2.1",
         "d3-geo": "^2.0.2",
         "d3-geo-projection": "^3.0.0",
+        "liquidjs": "^10.26.0",
         "luxon": "^1.28.1",
         "markdown-it": "^14.1.1",
         "markdown-it-footnote": "^3.0.3",
@@ -2770,9 +2771,9 @@
       }
     },
     "node_modules/liquidjs": {
-      "version": "10.24.0",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.24.0.tgz",
-      "integrity": "sha512-TAUNAdgwaAXjjcUFuYVJm9kOVH7zc0mTKxsG9t9Lu4qdWjB2BEblyVIYpjWcmJLMGgiYqnGNJjpNMHx0gp/46A==",
+      "version": "10.26.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.26.0.tgz",
+      "integrity": "sha512-Ub9FFNOLB9tdH/gB2MKkeU7x9NifoVidxAam6YWU7LUcy7Glumi6q5C3tDpWOEpeNaT8Cdwdb1axEdlvLSoyaQ==",
       "license": "MIT",
       "dependencies": {
         "commander": "^10.0.0"
@@ -6865,9 +6866,9 @@
       }
     },
     "liquidjs": {
-      "version": "10.24.0",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.24.0.tgz",
-      "integrity": "sha512-TAUNAdgwaAXjjcUFuYVJm9kOVH7zc0mTKxsG9t9Lu4qdWjB2BEblyVIYpjWcmJLMGgiYqnGNJjpNMHx0gp/46A==",
+      "version": "10.26.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.26.0.tgz",
+      "integrity": "sha512-Ub9FFNOLB9tdH/gB2MKkeU7x9NifoVidxAam6YWU7LUcy7Glumi6q5C3tDpWOEpeNaT8Cdwdb1axEdlvLSoyaQ==",
       "requires": {
         "commander": "^10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "clean-css": "^4.2.1",
     "d3-geo": "^2.0.2",
     "d3-geo-projection": "^3.0.0",
+    "liquidjs": "^10.26.0",
     "luxon": "^1.28.1",
     "markdown-it": "^14.1.1",
     "markdown-it-footnote": "^3.0.3",


### PR DESCRIPTION
## Summary
Upgrade liquidjs from 10.24.0 to 10.26.0 to fix CVE-2026-45618.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-45618 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-45618` |
| **File** | `package-lock.json` |
| **Assessment** | Likely exploitable |

**Description**: LiquidJS is Vulnerable to Remote Code Execution

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-45618` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `package.json`
- `package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
